### PR TITLE
Fix IMGHDR_TYPE_*

### DIFF
--- a/src/freetype/cache.c
+++ b/src/freetype/cache.c
@@ -47,8 +47,8 @@ static SIE_FT_GLYPH_CACHE *AddGlyphCache(FT_Face *face, SIE_FT_CACHE *ft_cache, 
     IMGHDR *img = malloc(sizeof(IMGHDR));
     img->w = bitmap->width;
     img->h = bitmap->rows;
-    img->bpnum = IMGHDR_TYPE_RGB8888;
-    img->bitmap = malloc(CalcBitmapSize(img->w, img->h, IMGHDR_TYPE_RGB8888));
+    img->bpnum = IMGHDR_TYPE_BGRA8888;
+    img->bitmap = malloc(CalcBitmapSize(img->w, img->h, IMGHDR_TYPE_BGRA8888));
 
     uint8_t im[img->h][img->w];
     for (int _y = 0, j = 0; _y < img->h; _y++) {

--- a/src/freetype/freetype.c
+++ b/src/freetype/freetype.c
@@ -92,7 +92,7 @@ void Sie_FT_GetStringSize(WSHDR *ws, int font_size, unsigned int *w, unsigned in
 IMGHDR *BrushGlyphIMGHDR(IMGHDR *img, const char *color) {
     IMGHDR *res = malloc(sizeof(IMGHDR));
     memcpy(res, img, sizeof(IMGHDR));
-    size_t size = CalcBitmapSize((short)res->w, (short)res->h, IMGHDR_TYPE_RGB8888);
+    size_t size = CalcBitmapSize((short)res->w, (short)res->h, IMGHDR_TYPE_BGRA8888);
     res->bitmap = malloc(size);
     memcpy(res->bitmap, img->bitmap, size);
     for (int i = 0; i < size; i += 4) {

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -72,10 +72,10 @@ void Sie_GUI_SetRGB(char *rgb, char r, char g, char b) {
 IMGHDR *Sie_GUI_TakeScrot() {
     LockSched();
     IMGHDR *scrot = malloc(sizeof(IMGHDR));
-    size_t size = CalcBitmapSize((short) ScreenW(), (short) ScreenH(), IMGHDR_TYPE_RGB565);
+    size_t size = CalcBitmapSize((short) ScreenW(), (short) ScreenH(), IMGHDR_TYPE_BGR565);
     scrot->w = ScreenW();
     scrot->h = ScreenH();
-    scrot->bpnum = IMGHDR_TYPE_RGB565;
+    scrot->bpnum = IMGHDR_TYPE_BGR565;
     scrot->bitmap = malloc(size);
     memcpy(scrot->bitmap, RamScreenBuffer(), size);
     UnlockSched();


### PR DESCRIPTION
Поправил название, чтобы не было путаницы. Порядок байт в сименсе [ BB, GG, RR, AA ], поэтому правильное название констант BGR* и BGRA* вместо RGB* и RGBA*

1. Константа появилась недавно, поэтому старые эльфы не затронет.
2. Пересобирать эльфы не нужно.